### PR TITLE
implemented onecold for maybehots which don't contain missings

### DIFF
--- a/src/Mill.jl
+++ b/src/Mill.jl
@@ -47,7 +47,7 @@ export ArrayNode, BagNode, WeightedBagNode, ProductNode, LazyNode
 export catobs, removeinstances, dropmeta
 
 include("special_arrays/special_arrays.jl")
-export MaybeHotVector, MaybeHotMatrix, maybehot, maybehotbatch
+export MaybeHotVector, MaybeHotMatrix, maybehot, maybehotbatch, maybecold
 export NGramMatrix, NGramIterator, ngrams, ngrams!, countngrams, countngrams!
 export ImputingMatrix, PreImputingMatrix, PostImputingMatrix
 export ImputingDense, PreImputingDense, PostImputingDense

--- a/src/special_arrays/maybe_hot_matrix.jl
+++ b/src/special_arrays/maybe_hot_matrix.jl
@@ -80,10 +80,7 @@ function _mul(A::AbstractMatrix, B::MaybeHotMatrix)
 end
 
 # this is a bit shady because we're overloading unexported method not intended for public use
-Flux._fast_argmax(x::MaybeHotMatrix{<:Integer}) = x.I
-# this returns different type
-Flux._fast_argmax(x::MaybeHotMatrix{<:Maybe{Integer}}) = x.I
-
+Flux._fast_argmax(X::MaybeHotMatrix) = X.I
 Flux.onehotbatch(X::MaybeHotMatrix{<:Integer}) = Flux.onehotbatch(X.I, 1:X.l)
 
 """

--- a/src/special_arrays/maybe_hot_matrix.jl
+++ b/src/special_arrays/maybe_hot_matrix.jl
@@ -79,7 +79,10 @@ function _mul(A::AbstractMatrix, B::MaybeHotMatrix)
     C
 end
 
-_fast_argmax(x::MaybeHotMatrix{<:Integer}) = x.I
+# this is a bit shady because we're overloading unexported method not intended for public use
+Flux._fast_argmax(x::MaybeHotMatrix{<:Integer}) = x.I
+# this returns different type
+Flux._fast_argmax(x::MaybeHotMatrix{<:Maybe{Integer}}) = x.I
 
 Flux.onehotbatch(X::MaybeHotMatrix{<:Integer}) = Flux.onehotbatch(X.I, 1:X.l)
 

--- a/src/special_arrays/maybe_hot_matrix.jl
+++ b/src/special_arrays/maybe_hot_matrix.jl
@@ -79,6 +79,8 @@ function _mul(A::AbstractMatrix, B::MaybeHotMatrix)
     C
 end
 
+_fast_argmax(x::MaybeHotMatrix{<:Integer}) = x.I
+
 Flux.onehotbatch(X::MaybeHotMatrix{<:Integer}) = Flux.onehotbatch(X.I, 1:X.l)
 
 """

--- a/src/special_arrays/maybe_hot_vector.jl
+++ b/src/special_arrays/maybe_hot_vector.jl
@@ -65,12 +65,12 @@ _mul(A::AbstractMatrix, b::MaybeHotVector{Missing}) = fill(missing, size(A, 1))
 _mul(A::AbstractMatrix, b::MaybeHotVector{<:Integer}) = A[:, b.i]
 
 # this is a bit shady because we're overloading unexported method not intended for public use
-Flux._fast_argmax(x::MaybeHotVector{<:Integer}) = x.i
-# this returns different type
-Flux._fast_argmax(x::MaybeHotVector{<:Maybe{Integer}}) = x.i
+Flux._fast_argmax(x::MaybeHotVector) = x.i
 
 Flux.onehot(x::MaybeHotVector{<:Integer}) = Flux.onehot(x.i, 1:x.l)
-maybecold(x::MaybeHotVector{<:Maybe{Integer}}, labels = 1:length(y)) = ismissing(x.i) ? x.i : labels[argmax(x)]
+maybecold(x::MaybeHotVector{<:Maybe{Integer}}, labels = 1:length(x)) = ismissing(x.i) ? x.i : labels[argmax(x)]
+maybecold(x::MaybeHotVector{Missing}, labels = 1:length(x)) = missing
+maybecold(x::MaybeHotVector{<:Integer}, labels = 1:length(x)) = labels[x.i]
 
 """
     maybehot(l, labels)

--- a/src/special_arrays/maybe_hot_vector.jl
+++ b/src/special_arrays/maybe_hot_vector.jl
@@ -64,6 +64,8 @@ Zygote.@adjoint A::AbstractMatrix * b::MaybeHotVector = (_check_mul(A, b); Zygot
 _mul(A::AbstractMatrix, b::MaybeHotVector{Missing}) = fill(missing, size(A, 1))
 _mul(A::AbstractMatrix, b::MaybeHotVector{<:Integer}) = A[:, b.i]
 
+_fast_argmax(x::MaybeHotVector{<:Integer}) = x.i
+
 Flux.onehot(x::MaybeHotVector{<:Integer}) = Flux.onehot(x.i, 1:x.l)
 
 """

--- a/src/special_arrays/maybe_hot_vector.jl
+++ b/src/special_arrays/maybe_hot_vector.jl
@@ -68,7 +68,6 @@ _mul(A::AbstractMatrix, b::MaybeHotVector{<:Integer}) = A[:, b.i]
 Flux._fast_argmax(x::MaybeHotVector) = x.i
 
 Flux.onehot(x::MaybeHotVector{<:Integer}) = Flux.onehot(x.i, 1:x.l)
-maybecold(x::MaybeHotVector{<:Maybe{Integer}}, labels = 1:length(x)) = ismissing(x.i) ? x.i : labels[argmax(x)]
 maybecold(x::MaybeHotVector{Missing}, labels = 1:length(x)) = missing
 maybecold(x::MaybeHotVector{<:Integer}, labels = 1:length(x)) = labels[x.i]
 

--- a/src/special_arrays/maybe_hot_vector.jl
+++ b/src/special_arrays/maybe_hot_vector.jl
@@ -70,6 +70,7 @@ Flux._fast_argmax(x::MaybeHotVector{<:Integer}) = x.i
 Flux._fast_argmax(x::MaybeHotVector{<:Maybe{Integer}}) = x.i
 
 Flux.onehot(x::MaybeHotVector{<:Integer}) = Flux.onehot(x.i, 1:x.l)
+maybecold(x::MaybeHotVector{<:Maybe{Integer}}, labels = 1:length(y)) = ismissing(x.i) ? x.i : labels[argmax(x)]
 
 """
     maybehot(l, labels)

--- a/src/special_arrays/maybe_hot_vector.jl
+++ b/src/special_arrays/maybe_hot_vector.jl
@@ -64,7 +64,10 @@ Zygote.@adjoint A::AbstractMatrix * b::MaybeHotVector = (_check_mul(A, b); Zygot
 _mul(A::AbstractMatrix, b::MaybeHotVector{Missing}) = fill(missing, size(A, 1))
 _mul(A::AbstractMatrix, b::MaybeHotVector{<:Integer}) = A[:, b.i]
 
-_fast_argmax(x::MaybeHotVector{<:Integer}) = x.i
+# this is a bit shady because we're overloading unexported method not intended for public use
+Flux._fast_argmax(x::MaybeHotVector{<:Integer}) = x.i
+# this returns different type
+Flux._fast_argmax(x::MaybeHotVector{<:Maybe{Integer}}) = x.i
 
 Flux.onehot(x::MaybeHotVector{<:Integer}) = Flux.onehot(x.i, 1:x.l)
 

--- a/src/special_arrays/special_arrays.jl
+++ b/src/special_arrays/special_arrays.jl
@@ -1,5 +1,3 @@
-import Flux: onecold
-
 # TODO replace all @adjoints in matrices by rrules once Tangent gradients become available
 # https://github.com/FluxML/Zygote.jl/issues/603
 
@@ -31,12 +29,12 @@ const ImputingMatrix{T, U} = Union{PreImputingMatrix{T, U}, PostImputingMatrix{T
 const PreImputingDense = Dense{T, <: PreImputingMatrix} where T
 const PostImputingDense = Dense{T, <: PostImputingMatrix} where T
 
-# basically copied from https://github.com/FluxML/Flux.jl/blob/v0.12.7/src/onehot.jl#L204-L209 because 
-# I don't want to overload non-exposed functions
-function onecold(y::MaybeHotArray{<:Integer}, labels = 1:size(y, 1))
-    indices = _fast_argmax(y)
+Flux.onecold(y::MaybeHotArray{<:Maybe{Integer}}, labels = 1:size(y, 1)) = 
+    ArgumentError("MaybeHotArray{<:Maybe{Integer}} can't produce onecold encoding, use maybecold instead.")
+
+function maybecold(y::AbstractArray, labels = 1:size(y, 1))
+    indices = Flux._fast_argmax(y)
     xs = isbits(labels) ? indices : collect(indices) # non-bit type cannot be handled by CUDA
-  
     return map(xi -> labels[xi[1]], xs)
 end
 

--- a/src/special_arrays/special_arrays.jl
+++ b/src/special_arrays/special_arrays.jl
@@ -1,3 +1,5 @@
+import Flux: onecold
+
 # TODO replace all @adjoints in matrices by rrules once Tangent gradients become available
 # https://github.com/FluxML/Zygote.jl/issues/603
 
@@ -28,6 +30,15 @@ const MaybeHotArray{T} = Union{MaybeHotVector{T}, MaybeHotMatrix{T}}
 const ImputingMatrix{T, U} = Union{PreImputingMatrix{T, U}, PostImputingMatrix{T, U}}
 const PreImputingDense = Dense{T, <: PreImputingMatrix} where T
 const PostImputingDense = Dense{T, <: PostImputingMatrix} where T
+
+# basically copied from https://github.com/FluxML/Flux.jl/blob/v0.12.7/src/onehot.jl#L204-L209 because 
+# I don't want to overload non-exposed functions
+function onecold(y::MaybeHotArray{<:Integer}, labels = 1:size(y, 1))
+    indices = _fast_argmax(y)
+    xs = isbits(labels) ? indices : collect(indices) # non-bit type cannot be handled by CUDA
+  
+    return map(xi -> labels[xi[1]], xs)
+end
 
 Base.zero(X::T) where T <: ImputingMatrix = T(zero(X.W), zero(X.ψ))
 Base.similar(X::T) where T <: ImputingMatrix = T(similar(X.W), similar(X.ψ))

--- a/src/special_arrays/special_arrays.jl
+++ b/src/special_arrays/special_arrays.jl
@@ -29,10 +29,9 @@ const ImputingMatrix{T, U} = Union{PreImputingMatrix{T, U}, PostImputingMatrix{T
 const PreImputingDense = Dense{T, <: PreImputingMatrix} where T
 const PostImputingDense = Dense{T, <: PostImputingMatrix} where T
 
-# so we error on integers with missings
+# so we error on integers with missings (but not on maybehot which has only integers)
 Flux.onecold(X::MaybeHotArray{Maybe{T}}, labels = 1:size(X, 1)) where T<:Integer = 
     throw(ArgumentError("$(typeof(X)) can't produce `onecold` encoding, use `maybecold` instead."))
-# but we don't error on maybehot which has only integers
 
 function maybecold(X::MaybeHotMatrix{<:Maybe{Integer}}, labels = 1:size(X, 1))
     indices = Flux._fast_argmax(X)

--- a/src/special_arrays/special_arrays.jl
+++ b/src/special_arrays/special_arrays.jl
@@ -33,6 +33,37 @@ const PostImputingDense = Dense{T, <: PostImputingMatrix} where T
 Flux.onecold(X::MaybeHotArray{Maybe{T}}, labels = 1:size(X, 1)) where T<:Integer = 
     throw(ArgumentError("$(typeof(X)) can't produce `onecold` encoding, use `maybecold` instead."))
 
+"""
+    maybecold(y::AbstractArray, labels = 1:size(y,1))
+
+Roughly the inverse operation of [`maybehot`](@ref) or [`maybehotbatch`](@ref): 
+This finds the index of the largest element of `y`, or each column of `y`, 
+and looks them up in `labels`.
+If `labels` are not specified, the default is integers `1:size(y,1)` --
+the roughly same operation as `argmax(y, dims=1)` but sometimes a different return type
+and can handle missings.
+# Examples
+```jldoctest
+julia> maybecold(maybehot(:b, [:a, :b, :c]))
+2
+julia> maybecold(maybehot(:b, [:a, :b, :c]), [:a, :b, :c])
+:b
+julia> maybehot(missing, 1:3)
+3-element MaybeHotVector with eltype Missing:
+ missing
+ missing
+ missing
+julia> maybecold(maybehotbatch(1:3, 1:10))
+3-element Vector{Int64}:
+ 1
+ 2
+ 3
+julia> maybecold(maybehotbatch([missing, 2], 1:3))
+2-element Vector{Union{Missing, Int64}}:
+  missing
+ 2
+```
+"""
 function maybecold(X::MaybeHotMatrix{<:Maybe{Integer}}, labels = 1:size(X, 1))
     indices = Flux._fast_argmax(X)
     xs = isbits(labels) ? indices : collect(indices) # non-bit type cannot be handled by CUDA

--- a/src/special_arrays/special_arrays.jl
+++ b/src/special_arrays/special_arrays.jl
@@ -30,16 +30,16 @@ const PreImputingDense = Dense{T, <: PreImputingMatrix} where T
 const PostImputingDense = Dense{T, <: PostImputingMatrix} where T
 
 # so we error on integers with missings
-Flux.onecold(y::MaybeHotArray{Maybe{T}}, labels = 1:size(y, 1)) where T<:Integer = 
-    throw(ArgumentError("MaybeHotArray{Union{T, Missing}} where T <:Integer can't produce onecold encoding, use maybecold instead."))
+Flux.onecold(X::MaybeHotArray{Maybe{T}}, labels = 1:size(X, 1)) where T<:Integer = 
+    throw(ArgumentError("$(typeof(X)) can't produce `onecold` encoding, use `maybecold` instead."))
 # but we don't error on maybehot which has only integers
 
-y = maybehotbatch([1, missing, 3], 1:10)
-function maybecold(y::AbstractArray, labels = 1:size(y, 1))
-    indices = Flux._fast_argmax(y)
+function maybecold(X::MaybeHotMatrix{<:Maybe{Integer}}, labels = 1:size(X, 1))
+    indices = Flux._fast_argmax(X)
     xs = isbits(labels) ? indices : collect(indices) # non-bit type cannot be handled by CUDA
     return map(xi -> ismissing(xi) ? xi : labels[xi[1]], xs)
 end
+maybecold(X::MaybeHotMatrix{<:Integer}, labels = 1:size(X, 1)) = Flux.onecold(X, labels)
 
 Base.zero(X::T) where T <: ImputingMatrix = T(zero(X.W), zero(X.ψ))
 Base.similar(X::T) where T <: ImputingMatrix = T(similar(X.W), similar(X.ψ))

--- a/test/maybe_hot.jl
+++ b/test/maybe_hot.jl
@@ -267,8 +267,7 @@ end
     t3 = Flux.onehot(3, 1:10)
     t4 = maybehot(3, 1:10)
     @test Flux.onecold(t3) == Flux.onecold(t4)
-t3
-@which Flux.onecold(t3)
+
     t5 = maybehotbatch([1, missing, 3], 1:10)
     @test_throws ArgumentError Flux.onecold(t5)
 

--- a/test/maybe_hot.jl
+++ b/test/maybe_hot.jl
@@ -268,5 +268,8 @@ end
     t4 = maybehot(3, 1:10)
     @test Flux.onecold(t3) == Flux.onecold(t4)
 
+    t4 = maybehotbatch([1, missing, 3], 1:10)
+    Flux.onecold(t4)
+    methods(Flux.onecold)
     @test_throws MethodError maybehotbatch([1,missing,3], 1:10) |> Flux.onecold
 end

--- a/test/maybe_hot.jl
+++ b/test/maybe_hot.jl
@@ -258,3 +258,15 @@ end
     @test mhm isa AbstractMatrix{Union{Bool, Missing}}
     @test mhm isa MaybeHotMatrix{Union{UInt32, Missing}}
 end
+
+@testset "onecold" begin
+    t = Flux.onehotbatch(1:3, 1:10)
+    t2 = maybehotbatch(1:3, 1:10)
+    @test Flux.onecold(t) == Flux.onecold(t2)
+
+    t3 = Flux.onehot(3, 1:10)
+    t4 = maybehot(3, 1:10)
+    @test Flux.onecold(t3) == Flux.onecold(t4)
+
+    @test_throws MethodError maybehotbatch([1,missing,3], 1:10) |> Flux.onecold
+end

--- a/test/maybe_hot.jl
+++ b/test/maybe_hot.jl
@@ -267,9 +267,16 @@ end
     t3 = Flux.onehot(3, 1:10)
     t4 = maybehot(3, 1:10)
     @test Flux.onecold(t3) == Flux.onecold(t4)
+t3
+@which Flux.onecold(t3)
+    t5 = maybehotbatch([1, missing, 3], 1:10)
+    @test_throws ArgumentError Flux.onecold(t5)
 
-    t4 = maybehotbatch([1, missing, 3], 1:10)
-    Flux.onecold(t4)
-    methods(Flux.onecold)
-    @test_throws MethodError maybehotbatch([1,missing,3], 1:10) |> Flux.onecold
+    t6 = maybehot(missing, 1:10)
+    @test_throws ArgumentError Flux.onecold(t6)
+
+    @test Flux.onecold(t2) == maybecold(t2)
+    @test Flux.onecold(t4) == maybecold(t4)
+    @test areequal([1, missing, 3], maybecold(t5))
+    @test areequal(missing, maybecold(t6))
 end


### PR DESCRIPTION
Fixes #83 .
Allows calling `Flux.onecold` for `MaybeHotArray{<:Integer}` which is useful if we want to use JsonGrinder to encode labels.
Adds `maybecold` which is same to `onecold` as `maybehot` is for `onehot`.