### PR TITLE
skipping derivation of reduce catobs and adding helper functions

### DIFF
--- a/src/datanodes/datanode.jl
+++ b/src/datanodes/datanode.jl
@@ -250,3 +250,5 @@ Base.reduce(::typeof(catobs), as::Vector{Union{Missing, Nothing}}) = nothing
 function Base.reduce(::typeof(catobs), as::Vector{Maybe{T}}) where T <: AbstractMillNode
     reduce(catobs, skipmissing(as) |> collect)
 end
+
+ChainRulesCore.@non_differentiable Base.reduce(catobs, x::AbstractVector{<:AbstractMillNode})

--- a/src/modelnodes/arraymodel.jl
+++ b/src/modelnodes/arraymodel.jl
@@ -44,6 +44,8 @@ function (m::ArrayModel)(x::ArrayNode)
     ArrayNode(c(a))
 end
 
+(m::ArrayModel)(x::AbstractVector{<:ArrayNode}) = m(reduce(catobs, x))
+
 """
     identity_model()
 

--- a/src/modelnodes/bagmodel.jl
+++ b/src/modelnodes/bagmodel.jl
@@ -74,6 +74,7 @@ end
 (m::BagModel)(x::BagNode{Missing}) = m.bm(ArrayNode(m.a(getfield(x, :data), x.bags)))
 (m::BagModel)(x::WeightedBagNode{<:AbstractMillNode}) = m.bm(m.a(m.im(getfield(x, :data)), x.bags, x.weights))
 (m::BagModel)(x::WeightedBagNode{Missing}) = m.bm(ArrayNode(m.a(getfield(x, :data), x.bags, x.weights)))
+(m::BagModel)(x::AbstractVector{<:BagNode}) = m(reduce(catobs, x))
 
 function _bag_forward(m, x)
     im = getfield(m, :im)

--- a/src/modelnodes/lazymodel.jl
+++ b/src/modelnodes/lazymodel.jl
@@ -61,6 +61,7 @@ LazyModel{Name}(m::M) where {Name, M} = LazyModel{Name, M}(m)
 Flux.@functor LazyModel
 
 (m::LazyModel{Name})(x::LazyNode{Name}) where {Name} = m.m(unpack2mill(x))
+(m::LazyModel{Name})(x::AbstractVector{<:LazyNode{Name}}) where {Name} = m(reduce(catobs, x))
 
 function HiddenLayerModel(m::LazyModel{N}, ds::LazyNode{N}, n) where {N}
     hm, o = HiddenLayerModel(m.m, unpack2mill(ds), n)

--- a/src/modelnodes/productmodel.jl
+++ b/src/modelnodes/productmodel.jl
@@ -105,3 +105,5 @@ function (m::ProductModel{<:NamedTuple})(x::ProductNode{<:NamedTuple})
     cm = getfield(m, :m)
     cm(vcat(map((sm, sx) -> sm(sx), ms, getfield(x, :data))...))
 end
+
+(m::ProductModel)(x::AbstractVector{<:ProductNode}) = m(reduce(catobs, x))

--- a/test/modelnode.jl
+++ b/test/modelnode.jl
@@ -338,3 +338,13 @@ end
         end
     end
 end
+
+@testset "testing simple named tuple model with reduce catobs in gradient" begin
+    x = ProductNode((node1 = BagNode(ArrayNode(randn(Float32, 3, 4)), [1:2, 3:4]),
+                     node2 = BagNode(ArrayNode(randn(Float32, 4, 4)), [1:1, 2:4])))
+    m = reflectinmodel(x, layerbuilder)
+    @test gradient(() -> sum(m([x, x]).data), params(m)) isa Flux.Zygote.Grads
+    @test gradient(() -> sum(m[:node1]([x[:node1], x[:node1]]).data), params(m)) isa Flux.Zygote.Grads
+    reduced = reduce(catobs, [x, x])
+    @test gradient(() -> sum(m([x, x]).data), params(m)).params == gradient(() -> sum(m(reduced).data), params(m)).params
+end


### PR DESCRIPTION
skipping derivation of reduce catobs, adding option to perform reduce catobs before inference inside model call
Fixes #90 .